### PR TITLE
Fix Customize() linting and Project external-name

### DIFF
--- a/apis/project/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/project/v1alpha1/zz_generated.deepcopy.go
@@ -312,6 +312,11 @@ func (in *ProjectParameters) DeepCopyInto(out *ProjectParameters) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Name != nil {
+		in, out := &in.Name, &out.Name
+		*out = new(string)
+		**out = **in
+	}
 	if in.OrganizationID != nil {
 		in, out := &in.OrganizationID, &out.OrganizationID
 		*out = new(string)

--- a/apis/project/v1alpha1/zz_project_types.go
+++ b/apis/project/v1alpha1/zz_project_types.go
@@ -62,6 +62,10 @@ type ProjectParameters struct {
 	// +kubebuilder:validation:Optional
 	BgpConfig []BgpConfigParameters `json:"bgpConfig,omitempty" tf:"bgp_config,omitempty"`
 
+	// The name of the project
+	// +kubebuilder:validation:Required
+	Name *string `json:"name" tf:"name,omitempty"`
+
 	// The UUID of organization under which you want to create the project. If you leave it out, the project will be create under your the default organization of your account
 	// +kubebuilder:validation:Optional
 	OrganizationID *string `json:"organizationId,omitempty" tf:"organization_id,omitempty"`

--- a/config/device/config.go
+++ b/config/device/config.go
@@ -2,6 +2,7 @@ package device
 
 import "github.com/crossplane-contrib/terrajet/pkg/config"
 
+// Customize the device group with references to other resources
 func Customize(p *config.Provider) {
 	p.AddResourceConfigurator("metal_device", func(r *config.Resource) {
 		r.Group = "device"

--- a/config/project/config.go
+++ b/config/project/config.go
@@ -5,6 +5,7 @@ import "github.com/crossplane-contrib/terrajet/pkg/config"
 // Customize the device group with references to other resources
 func Customize(p *config.Provider) {
 	p.AddResourceConfigurator("metal_project", func(r *config.Resource) {
+		r.ExternalName = config.IdentifierFromProvider
 		r.Group = "project"
 	})
 }

--- a/config/project/config.go
+++ b/config/project/config.go
@@ -2,6 +2,7 @@ package project
 
 import "github.com/crossplane-contrib/terrajet/pkg/config"
 
+// Customize the device group with references to other resources
 func Customize(p *config.Provider) {
 	p.AddResourceConfigurator("metal_project", func(r *config.Resource) {
 		r.Group = "project"

--- a/internal/controller/project/project/zz_controller.go
+++ b/internal/controller/project/project/zz_controller.go
@@ -47,6 +47,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
+		managed.WithInitializers(),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/zz_setup.go
+++ b/internal/controller/zz_setup.go
@@ -36,14 +36,14 @@ import (
 	vlan "github.com/crossplane-contrib/provider-tf-equinixmetal/internal/controller/metal/vlan"
 	volume "github.com/crossplane-contrib/provider-tf-equinixmetal/internal/controller/metal/volume"
 	vlanattachment "github.com/crossplane-contrib/provider-tf-equinixmetal/internal/controller/port/vlanattachment"
-	apikeyproject "github.com/crossplane-contrib/provider-tf-equinixmetal/internal/controller/project/apikey"
+	apikey "github.com/crossplane-contrib/provider-tf-equinixmetal/internal/controller/project/apikey"
 	project "github.com/crossplane-contrib/provider-tf-equinixmetal/internal/controller/project/project"
 	sshkey "github.com/crossplane-contrib/provider-tf-equinixmetal/internal/controller/project/sshkey"
 	providerconfig "github.com/crossplane-contrib/provider-tf-equinixmetal/internal/controller/providerconfig"
 	ipblock "github.com/crossplane-contrib/provider-tf-equinixmetal/internal/controller/reserved/ipblock"
 	marketrequest "github.com/crossplane-contrib/provider-tf-equinixmetal/internal/controller/spot/marketrequest"
 	key "github.com/crossplane-contrib/provider-tf-equinixmetal/internal/controller/ssh/key"
-	apikey "github.com/crossplane-contrib/provider-tf-equinixmetal/internal/controller/user/apikey"
+	apikeyuser "github.com/crossplane-contrib/provider-tf-equinixmetal/internal/controller/user/apikey"
 	circuit "github.com/crossplane-contrib/provider-tf-equinixmetal/internal/controller/virtual/circuit"
 	attachment "github.com/crossplane-contrib/provider-tf-equinixmetal/internal/controller/volume/attachment"
 )
@@ -53,7 +53,7 @@ import (
 func Setup(mgr ctrl.Manager, l logging.Logger, wl workqueue.RateLimiter, ps terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	for _, setup := range []func(ctrl.Manager, logging.Logger, workqueue.RateLimiter, terraform.SetupFn, *terraform.WorkspaceStore, *tjconfig.Provider, int) error{
 		apikey.Setup,
-		apikeyproject.Setup,
+		apikeyuser.Setup,
 		attachment.Setup,
 		attachmentip.Setup,
 		circuit.Setup,

--- a/package/crds/project.equinixmetal.tf.crossplane.io_projects.yaml
+++ b/package/crds/project.equinixmetal.tf.crossplane.io_projects.yaml
@@ -103,6 +103,9 @@ spec:
                       - deploymentType
                       type: object
                     type: array
+                  name:
+                    description: The name of the project
+                    type: string
                   organizationId:
                     description: The UUID of organization under which you want to
                       create the project. If you leave it out, the project will be
@@ -113,6 +116,8 @@ spec:
                       payment method and the project need to belong to the same organization
                       (passed with organization_id, or default)
                     type: string
+                required:
+                - name
                 type: object
               providerConfigRef:
                 default:


### PR DESCRIPTION
`make reviewable` was failing due to missing comments in the `Customize` functions.

Projects should use external-name values derived from the UUID (which is the SetID value in Terraform) because project names are not uniquely constrained within Equinix Metal organizations.