### PR TITLE
fix max_retries and max_retry_wait_seconds provider settings

### DIFF
--- a/internal/clients/equinixmetal.go
+++ b/internal/clients/equinixmetal.go
@@ -31,9 +31,9 @@ import (
 )
 
 const (
-	keyAuthToken             = "auth_token"
-	keyMaxRetries            = "max_retries"
-	keyMaxRetriesWaitSeconds = "max_retries_wait_seconds"
+	keyAuthToken           = "auth_token"
+	keyMaxRetries          = "max_retries"
+	keyMaxRetryWaitSeconds = "max_retry_wait_seconds"
 
 	// EquinixMetal credentials environment variable names
 	envAuthToken = "METAL_AUTH_TOKEN"
@@ -86,9 +86,14 @@ func TerraformSetupBuilder(version, providerSource, providerVersion string) terr
 		}
 
 		// set provider configuration
-		ps.Configuration = map[string]interface{}{
-			keyMaxRetries:            equinixmetalCreds[keyMaxRetries],
-			keyMaxRetriesWaitSeconds: equinixmetalCreds[keyMaxRetriesWaitSeconds],
+		ps.Configuration = map[string]interface{}{}
+
+		// TODO(displague) Can optional configuration be handled better?
+		if equinixmetalCreds[keyMaxRetries] != "" {
+			ps.Configuration[keyMaxRetries] = equinixmetalCreds[keyMaxRetries]
+		}
+		if equinixmetalCreds[keyMaxRetryWaitSeconds] != "" {
+			ps.Configuration[keyMaxRetryWaitSeconds] = equinixmetalCreds[keyMaxRetryWaitSeconds]
 		}
 		// set environment variables for sensitive provider configuration
 		ps.Env = []string{


### PR DESCRIPTION
Fix errors caused by incorrect provider configuration key names and values:

```
  Warning  CannotObserveExternalResource  55s (x25 over 107s)  managed/device.equinixmetal.jet.crossplane.io/v1alpha1, kind=device  cannot run refresh: refresh failed: Extraneous JSON object property: No argument or block type is named "max_retries_wait_seconds".: File name: main.tf.json
Incorrect attribute value type: Inappropriate value for attribute "max_retries": a number is required.: File name: main.tf.json
```
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
